### PR TITLE
Fix php compatible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^5.6",
+        "php": ">=5.6",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.5"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5"


### PR DESCRIPTION
melhorenvio/shipment-sdk-php requires php ^5.6 -> your PHP version 7.4.16 does not satisfy that requirement.

^5.6 should be >=5.6